### PR TITLE
Configurable entertainment area

### DIFF
--- a/custom_components/huesyncbox/__init__.py
+++ b/custom_components/huesyncbox/__init__.py
@@ -75,8 +75,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
 
     # Register services on first entry
-    LOGGER.debug("async_setup_entry len(hass.data[DOMAIN].items()) = %s" % len(hass.data[DOMAIN].items()))
-
     global services_registered
     if not services_registered:
         await async_register_services(hass)
@@ -114,12 +112,10 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     try:
         await async_remove_entry_from_huesyncbox(entry)
     except Exception as e:
-        LOGGER.debug("Unregistering Philips Hue Play HDMI Sync Box failed: %s ", e)
+        LOGGER.warning("Unregistering Philips Hue Play HDMI Sync Box failed: %s ", e)
 
 
 async def async_register_services(hass: HomeAssistant):
-    LOGGER.debug("async_register_services")
-
     async def async_set_sync_state(call):
         entity_ids = await async_extract_entity_ids(hass, call)
         for _, entry in hass.data[DOMAIN].items():
@@ -162,7 +158,6 @@ async def async_register_services(hass: HomeAssistant):
 
 
 async def async_unregister_services(hass):
-    LOGGER.debug("async_unregister_services")
     hass.services.async_remove(DOMAIN, SERVICE_SET_SYNC_STATE)
     hass.services.async_remove(DOMAIN, SERVICE_SET_BRIGHTNESS)
     hass.services.async_remove(DOMAIN, SERVICE_SET_MODE)

--- a/custom_components/huesyncbox/__init__.py
+++ b/custom_components/huesyncbox/__init__.py
@@ -63,6 +63,9 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up a config entry for Philips Hue Play HDMI Sync Box."""
+
+    LOGGER.debug("%s async_setup_entry\nentry:\n%s\nhass.data\n%s" % (__name__, str(entry), hass.data[DOMAIN]))
+
     huesyncbox = HueSyncBox(hass, entry)
     hass.data[DOMAIN][entry.data["unique_id"]] = huesyncbox
 

--- a/custom_components/huesyncbox/config_flow.py
+++ b/custom_components/huesyncbox/config_flow.py
@@ -108,6 +108,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "registration_id":  self.context["registration_id"],
         }
 
+        LOGGER.debug("%s _async_create_entry_from_context\entry_data:\n%s\nhass.data\n%s" % (__name__, entry_data, hass.data[DOMAIN]))
+
         return self.async_create_entry(
             # Title should identify this entry, so use device name and lets include unique_id in case of multiple devices with the same name
             title=f"{entry_data['name']} ({entry_data['unique_id']})",

--- a/custom_components/huesyncbox/const.py
+++ b/custom_components/huesyncbox/const.py
@@ -11,6 +11,7 @@ SERVICE_SET_SYNC_STATE = 'set_sync_state'
 SERVICE_SET_BRIGHTNESS = 'set_brightness'
 SERVICE_SET_INTENSITY = 'set_intensity'
 SERVICE_SET_MODE = 'set_sync_mode'
+SERVICE_SET_ENTERTAINMENT_AREA = 'set_entertainment_area'
 
 ATTR_SYNC = 'sync'
 ATTR_SYNC_TOGGLE = 'sync_toggle'
@@ -46,3 +47,5 @@ INPUT_HDMI3 = 'input3'
 INPUT_HDMI4 = 'input4'
 
 INPUTS = [ INPUT_HDMI1, INPUT_HDMI2, INPUT_HDMI3, INPUT_HDMI4 ]
+
+ATTR_ENTERTAINMENT_AREA = "entertainment_area"

--- a/custom_components/huesyncbox/huesyncbox.py
+++ b/custom_components/huesyncbox/huesyncbox.py
@@ -22,6 +22,13 @@ class HueSyncBox:
         self.api = None # aiohuesyncbox instance
         self.entity = None # Mediaplayer entity
 
+    def __str__(self):
+        output = ""
+        output += f"{self.config_entry}\n"
+        output += f"{self.api}\n"
+        output += f"{self.entity}\n"
+        return output
+
     async def async_setup(self, tries=0):
         """Set up a huesyncbox based on host parameter."""
         hass = self.hass
@@ -114,6 +121,9 @@ async def async_register_aiohuesyncbox(hass, api):
 
 async def async_get_aiohuesyncbox_from_entry_data(entry_data):
     """Create a huesyncbox object from entry data."""
+
+    LOGGER.debug("%s async_get_aiohuesyncbox_from_entry_data\nentry_data:\n%s" % (__name__, str(entry_data)))
+
     return aiohuesyncbox.HueSyncBox(
         entry_data["host"],
         entry_data["unique_id"],

--- a/custom_components/huesyncbox/manifest.json
+++ b/custom_components/huesyncbox/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://github.com/mvdwetering/huesyncbox",
   "issue_tracker": "https://github.com/mvdwetering/huesyncbox/issues",
-  "requirements": ["aiohuesyncbox==0.0.16"],
+  "requirements": ["aiohuesyncbox==0.0.17"],
   "dependencies": [],
   "codeowners": [
     "@mvdwetering"

--- a/custom_components/huesyncbox/media_player.py
+++ b/custom_components/huesyncbox/media_player.py
@@ -162,12 +162,37 @@ class HueSyncBoxMediaPlayerEntity(MediaPlayerEntity):
                 self.async_schedule_update_ha_state()
                 break
 
+    def _get_entertainment_areas(self):
+        """List of available entertainment areas."""
+        areas = []
+        for area in self._huesyncbox.api.hue.groups:
+            areas.append(area.name)
+        return sorted(areas)
+
+    def _get_selected_entertainment_area(self):
+        """Return the name of the active entertainment area."""
+        hue_target = self._huesyncbox.api.execution.hue_target # note that this returns a string like "groups/123"
+        selected_area = None
+        try:
+            parts = hue_target.split('/')
+            id = parts[1]
+            for group in self._huesyncbox.api.hue.groups:
+                if group.id == id:
+                    selected_area = group.name
+                    break
+        except KeyError:
+            LOGGER.warning("Selected entertainment area not available in groups")
+        return selected_area
+
     @property
     def device_state_attributes(self):
         api = self._huesyncbox.api
         mode = api.execution.mode
+
         attributes =  {
             'mode': mode,
+            'entertainment_area_list': self._get_entertainment_areas(),
+            'entertainment_area': self._get_selected_entertainment_area()
         }
 
         if mode != 'powersave':

--- a/custom_components/huesyncbox/media_player.py
+++ b/custom_components/huesyncbox/media_player.py
@@ -26,8 +26,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Setup from config_entry."""
-    device = HueSyncBoxMediaPlayerEntity(hass.data[DOMAIN][config_entry.data["unique_id"]])
-    async_add_entities([device], update_before_add=True)
+    LOGGER.debug("%s async_setup_entry\nconfig_entry:\n%s\nhass.data\n%s" % (__name__, config_entry, str(hass.data[DOMAIN])))
+    entity = HueSyncBoxMediaPlayerEntity(hass.data[DOMAIN][config_entry.data["unique_id"]])
+    async_add_entities([entity], update_before_add=True)
 
 async def async_unload_entry(hass, config_entry):
     # Not sure what to do, entities seem to disappear by themselves

--- a/custom_components/huesyncbox/services.yaml
+++ b/custom_components/huesyncbox/services.yaml
@@ -45,6 +45,9 @@ set_sync_state:
     input_prev:
       description: Select previous input
       example: true
+    entertainment_area:
+      description: Entertainment area to select. Can be one of the names available in "entertainment_area_list" attribute.
+      example: 'TV Area'
 
 set_brightness:
   description: Set the brightnes on the sync box
@@ -78,3 +81,13 @@ set_intensity:
     mode:
       description: Optional mode to apply intensity to. If not set intensity is applied to current or last used mode.
       example: 'video'
+
+set_entertainment_area:
+  description: Select entertainment area
+  fields:
+    entity_id:
+      description: Name(s) of entities to select entertainment area for.
+      example: 'media_player.huesyncbox'
+    entertainment_area:
+      description: Entertainment area to select. Can be one of the names available in "entertainment_area_list" attribute.
+      example: 'TV Area'


### PR DESCRIPTION
Allow selecting of the entertainment area for this component.

Added attributes "entertainment_area_list" and "entertainment_area" that show available entertainment areas and the current selected one.

Added a service "set_entertainment_area" to set the entertainment_area (from the available ones listed in the attribute).
Extended `set_sync_state` service to allow also providing the entertainment_area

Implements issue #8 