### PR TITLE
Add basic manual configuration

### DIFF
--- a/custom_components/huesyncbox/config_flow.py
+++ b/custom_components/huesyncbox/config_flow.py
@@ -1,9 +1,11 @@
 """Config flow for Philips Hue Play HDMI Sync Box integration."""
 from __future__ import annotations
 
-import textwrap
+from voluptuous import Required, Schema
+
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
+from homeassistant.const import CONF_IP_ADDRESS, CONF_UNIQUE_ID
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.typing import ConfigType
 
@@ -27,7 +29,29 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input: ConfigType | None = None) -> FlowResult:
         """Handle a flow initialized by the user."""
-        return self.async_abort(reason="manual_not_supported")
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=Schema(
+                    {
+                        Required(CONF_IP_ADDRESS): str,
+                        Required(CONF_UNIQUE_ID): str,
+                    }
+                ),
+                errors=None,
+            )
+
+        entry_info = {
+            "host": user_input[CONF_IP_ADDRESS],
+            "port": 443,
+            "path": "/api",
+            "unique_id": user_input[CONF_UNIQUE_ID],
+            "name": "unknown_name",
+            "devicetype": "HSB1",
+        }
+
+        return await self.async_step_check(entry_info)
 
     async def async_step_link(self, user_input: ConfigType | None = None) -> FlowResult:
         """

--- a/custom_components/huesyncbox/config_flow.py
+++ b/custom_components/huesyncbox/config_flow.py
@@ -1,6 +1,8 @@
 """Config flow for Philips Hue Play HDMI Sync Box integration."""
 from __future__ import annotations
 
+import textwrap
+
 from voluptuous import Required, Schema
 
 from homeassistant import config_entries

--- a/custom_components/huesyncbox/config_flow.py
+++ b/custom_components/huesyncbox/config_flow.py
@@ -49,7 +49,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             "port": 443,
             "path": "/api",
             "unique_id": user_input[CONF_UNIQUE_ID],
-            "name": "unknown_name",
+            "name": "Hue Sync Box",
             "devicetype": "HSB1",
         }
 

--- a/custom_components/huesyncbox/strings.json
+++ b/custom_components/huesyncbox/strings.json
@@ -3,9 +3,11 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "title": "Connect to the device",
+        "title": "Enter device information",
+        "description": "Details can be found in the Hue Sync Box App under 'Network and Device information'.",
         "data": {
-          "host": "Host"
+          "ip_address": "IP Address",
+          "unique_id": "Identifier (eg. C42996000000)"
         }
       },
       "link": {

--- a/custom_components/huesyncbox/strings.json
+++ b/custom_components/huesyncbox/strings.json
@@ -28,7 +28,7 @@
       "unknown": "Unknown error occurred",
       "cannot_connect": "Unable to connect to the device",
       "already_configured": "Device is already configured",
-      "already_in_progress": "Config flow for device is already in progress.",
+      "already_in_progress": "Config flow for device is already in progress."
    }
   },
   "device_automation": {

--- a/custom_components/huesyncbox/strings.json
+++ b/custom_components/huesyncbox/strings.json
@@ -29,7 +29,6 @@
       "cannot_connect": "Unable to connect to the device",
       "already_configured": "Device is already configured",
       "already_in_progress": "Config flow for device is already in progress.",
-      "manual_not_supported": "Manual configuration not supported. Devices should be discovered automatically."
    }
   },
   "device_automation": {

--- a/custom_components/huesyncbox/translations/en.json
+++ b/custom_components/huesyncbox/translations/en.json
@@ -3,9 +3,11 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "title": "Connect to the device",
+        "title": "Enter device information",
+        "description": "Details can be found in the Hue Sync Box App under 'Network and Device information'.",
         "data": {
-          "host": "Host"
+          "ip_address": "IP Address",
+          "unique_id": "Identifier (eg. C42996000000)"
         }
       },
       "link": {

--- a/custom_components/huesyncbox/translations/en.json
+++ b/custom_components/huesyncbox/translations/en.json
@@ -28,7 +28,7 @@
       "unknown": "Unknown error occurred",
       "cannot_connect": "Unable to connect to the device",
       "already_configured": "Device is already configured",
-      "already_in_progress": "Config flow for device is already in progress.",
+      "already_in_progress": "Config flow for device is already in progress."
    }
   },
   "device_automation": {

--- a/custom_components/huesyncbox/translations/en.json
+++ b/custom_components/huesyncbox/translations/en.json
@@ -29,7 +29,6 @@
       "cannot_connect": "Unable to connect to the device",
       "already_configured": "Device is already configured",
       "already_in_progress": "Config flow for device is already in progress.",
-      "manual_not_supported": "Manual configuration not supported. Devices should be discovered automatically."
    }
   },
   "device_automation": {

--- a/custom_components/huesyncbox/translations/nb.json
+++ b/custom_components/huesyncbox/translations/nb.json
@@ -28,7 +28,7 @@
       "unknown": "Det oppstod en ukjent feil",
       "cannot_connect": "Kan ikke koble til enheten",
       "already_configured": "Enheten er allerede konfigurert",
-      "already_in_progress": "Konfigurasjonsflyt for enheten pågår allerede.",
+      "already_in_progress": "Konfigurasjonsflyt for enheten pågår allerede."
    }
   },
   "device_automation": {

--- a/custom_components/huesyncbox/translations/nb.json
+++ b/custom_components/huesyncbox/translations/nb.json
@@ -29,7 +29,6 @@
       "cannot_connect": "Kan ikke koble til enheten",
       "already_configured": "Enheten er allerede konfigurert",
       "already_in_progress": "Konfigurasjonsflyt for enheten pågår allerede.",
-      "manual_not_supported": "Manuell konfigurasjon støttes ikke. Enheter bør oppdages automatisk."
    }
   },
   "device_automation": {

--- a/custom_components/huesyncbox/translations/nb.json
+++ b/custom_components/huesyncbox/translations/nb.json
@@ -3,9 +3,11 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "title": "Koble til enheten",
+        "title": "Enter device information",
+        "description": "Details can be found in the Hue Sync Box App under 'Network and Device information'.",
         "data": {
-          "host": "Vert"
+          "ip_address": "IP Address",
+          "unique_id": "Identifier (eg. C42996000000)"
         }
       },
       "link": {

--- a/custom_components/huesyncbox/translations/nl.json
+++ b/custom_components/huesyncbox/translations/nl.json
@@ -3,9 +3,11 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "title": "Verbind met het apparaat",
+        "title": "Vul apparaatgegevebs in",
+        "description": "Gegevens kunnen gevonden worden in de Hue Sync Box App bij 'Netwerk en apparaatinfo'.",
         "data": {
-          "host": "Host"
+          "ip_address": "IP Adres",
+          "unique_id": "Identificatie (bijvoorbeeld: C42996000000)"
         }
       },
       "link": {


### PR DESCRIPTION
Somehow I have issues with mDNS on my network and my Sync Box does not tell its there. This integration worked fine before but when I had to reinstall Home Assistant I was not able to set up my sync box.

With this workaround/feature I was able to configure my box. Maybe it is something you can use.