### PR TITLE
Replace deprecated SUPPORT_* constants for HA 2022.5.0

### DIFF
--- a/custom_components/huesyncbox/media_player.py
+++ b/custom_components/huesyncbox/media_player.py
@@ -6,20 +6,11 @@ import textwrap
 import aiohuesyncbox
 import async_timeout
 from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_BRIGHTNESS_STEP
-from homeassistant.components.media_player import MediaPlayerEntity
-from homeassistant.components.media_player.const import (
-    MEDIA_TYPE_MUSIC,
-    SUPPORT_NEXT_TRACK,
-    SUPPORT_PAUSE,
-    SUPPORT_PLAY,
-    SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_SELECT_SOUND_MODE,
-    SUPPORT_SELECT_SOURCE,
-    SUPPORT_STOP,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
-    SUPPORT_VOLUME_SET,
+from homeassistant.components.media_player import (
+    MediaPlayerEntity,
+    MediaPlayerEntityFeature,
 )
+from homeassistant.components.media_player.const import MEDIA_TYPE_MUSIC
 from homeassistant.const import STATE_IDLE, STATE_OFF, STATE_PLAYING
 
 from .const import (
@@ -48,16 +39,16 @@ from .huesyncbox import (
 )
 
 SUPPORT_HUESYNCBOX = (
-    SUPPORT_TURN_ON
-    | SUPPORT_TURN_OFF
-    | SUPPORT_SELECT_SOURCE
-    | SUPPORT_PLAY
-    | SUPPORT_PAUSE
-    | SUPPORT_STOP
-    | SUPPORT_VOLUME_SET
-    | SUPPORT_SELECT_SOUND_MODE
-    | SUPPORT_PREVIOUS_TRACK
-    | SUPPORT_NEXT_TRACK
+    MediaPlayerEntityFeature.TURN_ON
+    | MediaPlayerEntityFeature.TURN_OFF
+    | MediaPlayerEntityFeature.SELECT_SOURCE
+    | MediaPlayerEntityFeature.PLAY
+    | MediaPlayerEntityFeature.PAUSE
+    | MediaPlayerEntityFeature.STOP
+    | MediaPlayerEntityFeature.VOLUME_SET
+    | MediaPlayerEntityFeature.SELECT_SOUND_MODE
+    | MediaPlayerEntityFeature.PREVIOUS_TRACK
+    | MediaPlayerEntityFeature.NEXT_TRACK
 )
 
 SCAN_INTERVAL = timedelta(seconds=2)

--- a/hacs.json
+++ b/hacs.json
@@ -2,6 +2,6 @@
     "name": "Philips Hue Play HDMI Sync Box",
     "render_readme": true,
     "domains": ["media_player"],
-    "homeassistant": "2021.12.0",
+    "homeassistant": "2022.5.0",
     "iot_class": "Local Polling"
 }


### PR DESCRIPTION
In HA 2022.5 SUPPORT_* constants are deprecated. For more details see: https://developers.home-assistant.io/blog/2022/04/02/support-constants-deprecation/

This PR prepares for that change.
All code changes are done, but can not yet be merged because of dependencies

* Requires HA 2022.5.0 so that needs to be released
* pytest-homeassistant-custom-component needs to be updated