### PR TITLE
Fix connection by mac feature

### DIFF
--- a/custom_components/huesyncbox/helpers.py
+++ b/custom_components/huesyncbox/helpers.py
@@ -4,6 +4,7 @@ from typing import List
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from .const import DOMAIN, LOGGER, MANUFACTURER_NAME
 
@@ -23,6 +24,9 @@ async def update_device_registry(
         name=api.device.name,
         model=api.device.device_type,
         sw_version=api.device.firmware_version,
+        # Uniqueid seems to be the mac. Adding the connection allows other integrations
+        # like e.g. Mikrotik Router to link their entities to this device
+        connections={(CONNECTION_NETWORK_MAC, api.device.unique_id)},
     )
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,11 +13,26 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_UNIQUE_ID,
 )
-from homeassistant.helpers import entity_registry, issue_registry
+from homeassistant.helpers import entity_registry, issue_registry, device_registry
+
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry  # type: ignore
 
 from .conftest import setup_integration
+
+
+async def test_device_info(hass: HomeAssistant, mock_api):
+    integration = await setup_integration(hass, mock_api)
+
+    dr = device_registry.async_get(hass)
+    device = dr.async_get_device(identifiers={(huesyncbox.DOMAIN, "unique_id")})
+
+    assert device is not None
+    assert device.name == "Name"
+    assert device.manufacturer == "Signify"
+    assert device.model == "HSB1"
+    assert device.sw_version == "firmwareversion"
+    assert device.connections == {("mac", "unique_id")}
 
 
 async def test_handle_authentication_error_during_setup(hass: HomeAssistant, mock_api):


### PR DESCRIPTION
With the rewrite to 2.0.0 the device info does not include the mac connection anymore. This PR fixes this.