### PR TITLE
Let Home Assistant retry after integration setup fails

### DIFF
--- a/custom_components/huesyncbox/__init__.py
+++ b/custom_components/huesyncbox/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.components import automation
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryError
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import (
     entity_registry,
 )
@@ -47,7 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except aiohuesyncbox.Unauthorized as err:
         raise ConfigEntryAuthFailed(err) from err
     except aiohuesyncbox.RequestError as err:
-        raise ConfigEntryError(err) from err
+        raise ConfigEntryNotReady(err) from err
     finally:
         if not initialized:
             await api.close()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -53,7 +53,7 @@ async def test_handle_communication_error_during_setup(hass: HomeAssistant, mock
 
     config_entry = hass.config_entries.async_get_entry(integration.entry.entry_id)
     assert config_entry is not None
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state == ConfigEntryState.SETUP_RETRY
 
     assert mock_api.close.call_count == 1
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during setup by changing the raised exception to better reflect when the system is not ready, enhancing the user's ability to understand and respond to setup issues.

- **Tests**
  - Updated test cases to align with the new error handling logic, ensuring that the system behaves as expected during setup retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->