### PR TITLE
Do not trigger Github Action on all branches

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -2,6 +2,9 @@ name: Checks
 
 on:
   push:
+    branches:
+      - dev
+      - master  
   pull_request:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow triggers to activate on push events to both `dev` and `master` branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->