### PR TITLE
Split dev deps from test and only use test when testing

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -26,7 +26,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
           if [ -f requirements_test.txt ]; then pip install -r requirements_test.txt; fi
       - name: Test with pytest
         run: |

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,10 +1,3 @@
--r requirements.txt
-mypy==1.4.0
+-r requirements_test.txt
 
 homeassistant-stubs==2023.8.0
-pytest-homeassistant-custom-component==0.13.49
-
-# Not entirely clear why it is needed as not a requirement for huesyncbox directly
-# but the tests fail because HA seems to initialize the zeroconf component which fails due to missing lib.
-# Not sure why it started showing up now :/
-zeroconf

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,9 @@
+-r requirements.txt
+mypy==1.4.0
+
+pytest-homeassistant-custom-component==0.13.92
+
+# Not entirely clear why it is needed as not a requirement for huesyncbox directly
+# but the tests fail because HA seems to initialize the zeroconf component which fails due to missing lib.
+# Not sure why it started showing up now :/
+zeroconf

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,8 @@
 -r requirements.txt
+
 mypy==1.4.0
 
-pytest-homeassistant-custom-component==0.13.92
+pytest-homeassistant-custom-component==0.13.49
 
 # Not entirely clear why it is needed as not a requirement for huesyncbox directly
 # but the tests fail because HA seems to initialize the zeroconf component which fails due to missing lib.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the GitHub Actions workflow to streamline testing processes.
	- Refined testing dependencies to enhance the testing framework.
	- Switched testing reference to `requirements_test.txt` and removed specific dependencies.
	- Added additional testing dependencies in `requirements_test.txt`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->