### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Custom integration for the Philips Hue Play HDMI Sync Box.
 
 This integration exposes the Philips Hue Play HDMI Sync Box in Home Assistant so it can be used in automations or dashboards.
 
-The Philips Hue Play HDMI Sync Box will be discovered automatically in most cases and can be added manually through the `Settings > Devices and Services` menu in Home Assistant if that is not the case.
+The Philips Hue Play HDMI Sync Box will be discovered automatically in most cases and otherwise can be added manually through the `Settings > Devices and Services` menu in Home Assistant.
 
 The following features are available:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the guide on adding the Philips Hue Play HDMI Sync Box to Home Assistant, including manual addition instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->