### PR TITLE
Move service registration to setup

### DIFF
--- a/custom_components/huesyncbox/__init__.py
+++ b/custom_components/huesyncbox/__init__.py
@@ -11,8 +11,9 @@ from homeassistant.helpers import (
     entity_registry,
 )
 from homeassistant.helpers import issue_registry
+from homeassistant.helpers.typing import ConfigType
 
-from .services import async_register_services, async_unregister_services
+from .services import async_register_services
 
 from .const import (
     DOMAIN,
@@ -29,6 +30,12 @@ PLATFORMS: list[Platform] = [
 ]
 
 
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Philips Hue Play HDMI Sync Box integration."""
+    hass.data[DOMAIN] = {}
+    await async_register_services(hass)
+    return True
+    
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Philips Hue Play HDMI Sync Box from a config entry."""
 
@@ -57,11 +64,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = HueSyncBoxCoordinator(hass, api)
 
-    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    await async_register_services(hass)
 
     return True
 
@@ -71,10 +75,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         coordinator = hass.data[DOMAIN].pop(entry.entry_id)
         await coordinator.api.close()
-
-        if len(hass.data[DOMAIN]) == 0:
-            hass.data.pop(DOMAIN)
-            await async_unregister_services(hass)
 
     return unload_ok
 

--- a/custom_components/huesyncbox/services.py
+++ b/custom_components/huesyncbox/services.py
@@ -59,6 +59,7 @@ HUESYNCBOX_SET_SYNC_STATE_SCHEMA = make_entity_service_schema(
 
 
 async def async_register_services(hass: HomeAssistant):
+
     async def async_set_bridge(call):
         """
         Set bridge, note that this change is not instant.
@@ -79,13 +80,12 @@ async def async_register_services(hass: HomeAssistant):
 
                 await coordinator.api.hue.set_bridge(bridge_id, username, clientkey)
 
-    if not hass.services.has_service(DOMAIN, SERVICE_SET_BRIDGE):
-        hass.services.async_register(
-            DOMAIN,
-            SERVICE_SET_BRIDGE,
-            async_set_bridge,
-            schema=HUESYNCBOX_SET_BRIDGE_SCHEMA,
-        )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_BRIDGE,
+        async_set_bridge,
+        schema=HUESYNCBOX_SET_BRIDGE_SCHEMA,
+    )
 
     async def async_set_sync_state(call):
         """Set sync state, allow combining of all options."""
@@ -134,15 +134,9 @@ async def async_register_services(hass: HomeAssistant):
                     else:
                         raise
 
-    if not hass.services.has_service(DOMAIN, SERVICE_SET_SYNC_STATE):
-        hass.services.async_register(
-            DOMAIN,
-            SERVICE_SET_SYNC_STATE,
-            async_set_sync_state,
-            schema=HUESYNCBOX_SET_SYNC_STATE_SCHEMA,
-        )
-
-
-async def async_unregister_services(hass: HomeAssistant):
-    hass.services.async_remove(DOMAIN, SERVICE_SET_BRIDGE)
-    hass.services.async_remove(DOMAIN, SERVICE_SET_SYNC_STATE)
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_SYNC_STATE,
+        async_set_sync_state,
+        schema=HUESYNCBOX_SET_SYNC_STATE_SCHEMA,
+    )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -60,7 +60,6 @@ async def test_handle_communication_error_during_setup(hass: HomeAssistant, mock
 
 async def test_unload_entry(hass: HomeAssistant, mock_api):
     integration = await setup_integration(hass, mock_api)
-    integration2 = await setup_integration(hass, mock_api, entry_id="entry_id_2")
 
     # Unload first entry
     await hass.config_entries.async_unload(integration.entry.entry_id)
@@ -76,21 +75,6 @@ async def test_unload_entry(hass: HomeAssistant, mock_api):
     assert huesyncbox.DOMAIN in hass.data
     assert hass.services.has_service(huesyncbox.DOMAIN, "set_bridge")
     assert hass.services.has_service(huesyncbox.DOMAIN, "set_sync_state")
-
-    # Unload second entry
-    await hass.config_entries.async_unload(integration2.entry.entry_id)
-    await hass.async_block_till_done()
-
-    config_entry = hass.config_entries.async_get_entry(integration2.entry.entry_id)
-    assert config_entry is not None
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
-
-    assert mock_api.close.call_count == 2
-
-    # Check that data and services are cleaned up
-    assert huesyncbox.DOMAIN not in hass.data
-    assert not hass.services.has_service(huesyncbox.DOMAIN, "set_bridge")
-    assert not hass.services.has_service(huesyncbox.DOMAIN, "set_sync_state")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A coment on Discord suggests to move service registration to `async_setup` so they are always there which makes sense and avoids the hassle of re-registering when last entry was removed.

https://discord.com/channels/330944238910963714/330990195199442944/1225008139255025705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved setup and teardown processes for the Philips Hue Play HDMI Sync Box integration in Home Assistant, enhancing stability and simplification.
	- Streamlined service registration logic for a more efficient operation.
- **Tests**
	- Updated tests to better align with the refined integration unloading process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->