### PR TITLE
Remove issues section from NL translation

### DIFF
--- a/custom_components/huesyncbox/translations/nl.json
+++ b/custom_components/huesyncbox/translations/nl.json
@@ -229,18 +229,5 @@
         }
       }
     }
-  },
-  "issues": {
-    "automations_using_deleted_mediaplayer": {
-      "title": "Automations using deleted HueSyncBox mediaplayer",
-      "fix_flow": {
-        "step": {
-          "confirm": {
-            "title": "Update the automations",
-            "description": "The following automations are using a deleted HueSyncBox mediaplayer with id {media_player_entity}.\n\n{automations}\n\nPress SUBMIT to confirm the automations have been updated and dismiss this repair"
-          }
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed outdated translation entries related to deleted HueSyncBox mediaplayer automations from Dutch language support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->