### PR TITLE
Add content info sensor

### DIFF
--- a/custom_components/huesyncbox/sensor.py
+++ b/custom_components/huesyncbox/sensor.py
@@ -127,6 +127,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 
 class HueSyncBoxSensor(CoordinatorEntity, SensorEntity):
+    """Representation of a HueSyncBox sensor"""
+
     _attr_has_entity_name = True
 
     def __init__(
@@ -134,8 +136,7 @@ class HueSyncBoxSensor(CoordinatorEntity, SensorEntity):
         coordinator: HueSyncBoxCoordinator,
         entity_description: HueSyncBoxSensorEntityDescription,
     ):
-        """Pass coordinator to CoordinatorEntity."""
-        super().__init__(coordinator)
+        super().__init__(coordinator)  # Pass coordinator to CoordinatorEntity
         self.coordinator: HueSyncBoxCoordinator
 
         self.entity_description: HueSyncBoxSensorEntityDescription = entity_description
@@ -150,6 +151,7 @@ class HueSyncBoxSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
+        """Return the state of the sensor."""
         return self.entity_description.get_value(self.coordinator.api)
 
     @property

--- a/custom_components/huesyncbox/sensor.py
+++ b/custom_components/huesyncbox/sensor.py
@@ -101,6 +101,12 @@ ENTITY_DESCRIPTIONS = [
         entity_registry_enabled_default=False,  # type: ignore
         get_value=lambda api: WIFI_STRENGTH_STATES[api.device.wifi.strength],  # type: ignore
     ),
+    HueSyncBoxSensorEntityDescription(  # type: ignore
+        key="content_info",  # type: ignore
+        icon="mdi:aspect-ratio",  # type: ignore
+        entity_category=EntityCategory.DIAGNOSTIC,  # type: ignore
+        get_value=lambda api: api.hdmi.content_specs,  # type: ignore
+    ),
 ]
 
 

--- a/custom_components/huesyncbox/strings.json
+++ b/custom_components/huesyncbox/strings.json
@@ -137,6 +137,9 @@
           "good": "Good",
           "excellent": "Excellent"
         }
+      },
+      "content_info": {
+        "name": "Content info"
       }
     },
     "switch": {

--- a/custom_components/huesyncbox/translations/en.json
+++ b/custom_components/huesyncbox/translations/en.json
@@ -137,6 +137,9 @@
           "good": "Good",
           "excellent": "Excellent"
         }
+      },
+      "content_info": {
+        "name": "Content info"
       }
     },
     "switch": {

--- a/custom_components/huesyncbox/translations/nl.json
+++ b/custom_components/huesyncbox/translations/nl.json
@@ -137,6 +137,9 @@
           "good": "Goed",
           "excellent": "Uitstekend"
         }
+      },
+      "content_info": {
+        "name": "Signaal info"
       }
     },
     "switch": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,7 @@ def mock_api(hass):
     mock_api.hdmi.input4.name = "HDMI 4"
     mock_api.hdmi.input4.type = "generic"
     mock_api.hdmi.input4.status = "unknown"
+    mock_api.hdmi.content_specs = "1920 x 1080 @ 60 - SDR"
 
     mock_api.hue = Mock(aiohuesyncbox.hue.Hue)
     mock_api.hue.bridge_unique_id = "bridge_id"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -74,3 +74,11 @@ async def test_wifi_strength(hass: HomeAssistant, mock_api):
     assert entity is not None
     assert entity.state == "fair"
     assert entity.attributes["icon"] == "mdi:wifi-strength-2"
+
+async def test_content_info(hass: HomeAssistant, mock_api):
+    await setup_integration(hass, mock_api)
+
+    entity = hass.states.get("sensor.name_content_info")
+    assert entity is not None
+    assert entity.state == "1920 x 1080 @ 60 - SDR"
+

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -7,12 +7,12 @@ from .conftest import setup_integration
 
 async def test_sensor(hass: HomeAssistant, mock_api):
     await setup_integration(hass, mock_api)
-    assert hass.states.async_entity_ids_count("sensor") == 8
+    assert hass.states.async_entity_ids_count("sensor") == 9
 
 
 async def test_sensor_default_disabled(hass: HomeAssistant, mock_api):
     await setup_integration(hass, mock_api, disable_enable_default_all=True)
-    assert hass.states.async_entity_ids_count("sensor") == 4
+    assert hass.states.async_entity_ids_count("sensor") == 5
 
 
 async def test_hdmi_status(hass: HomeAssistant, mock_api):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,11 +1,10 @@
-from unittest.mock import call
-
 from homeassistant.core import HomeAssistant
 
 from .conftest import setup_integration
 
 
 async def test_sensor(hass: HomeAssistant, mock_api):
+    """Test the total count of sensor entities after integration setup."""
     await setup_integration(hass, mock_api)
     assert hass.states.async_entity_ids_count("sensor") == 9
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new "Content Info" sensor to the Hue Sync Box integration, displaying detailed content specifications.

- **Localization**
  - Updated translations to include "Content Info" in English and Dutch.

- **Tests**
  - Adjusted test cases to account for the new "Content Info" sensor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->