### PR TITLE
Fix dependencies

### DIFF
--- a/custom_components/huesyncbox/manifest.json
+++ b/custom_components/huesyncbox/manifest.json
@@ -10,14 +10,8 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mvdwetering/huesyncbox/issues",
-  "loggers": [
-    "aiohuesyncbox"
-  ],
-  "requirements": [
-    "aiohuesyncbox==0.0.27"
-  ],
-  "version": "2.1.0",
-  "zeroconf": [
-    "_huesync._tcp.local."
-  ]
+  "loggers": ["aiohuesyncbox"],
+  "requirements": ["aiohuesyncbox==0.0.27"],
+  "version": "0.0.0",
+  "zeroconf": ["_huesync._tcp.local."]
 }

--- a/custom_components/huesyncbox/manifest.json
+++ b/custom_components/huesyncbox/manifest.json
@@ -1,7 +1,6 @@
 {
   "domain": "huesyncbox",
   "name": "Philips Hue Play HDMI Sync Box",
-
   "codeowners": [
     "@mvdwetering"
   ],
@@ -11,8 +10,14 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mvdwetering/huesyncbox/issues",
-  "loggers": ["aiohuesyncbox"],
-  "requirements": ["aiohuesyncbox==0.0.27"],
-  "version": "0.0.0",
-  "zeroconf": ["_huesync._tcp.local."]
+  "loggers": [
+    "aiohuesyncbox"
+  ],
+  "requirements": [
+    "aiohuesyncbox==0.0.27"
+  ],
+  "version": "2.1.0",
+  "zeroconf": [
+    "_huesync._tcp.local."
+  ]
 }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
 -r requirements_test.txt
 
-homeassistant-stubs==2024.5.0
+homeassistant-stubs==2024.6.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,3 @@
 -r requirements_test.txt
 
-homeassistant-stubs==2024.4.0
+homeassistant-stubs==2024.5.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 
 mypy==1.4.0
 
-pytest-homeassistant-custom-component==0.13.111
+pytest-homeassistant-custom-component==0.13.120
 
 # Not entirely clear why it is needed as not a requirement for huesyncbox directly
 # but the tests fail because HA seems to initialize the zeroconf component which fails due to missing lib.

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 
 mypy==1.4.0
 
-pytest-homeassistant-custom-component==0.13.120
+pytest-homeassistant-custom-component==0.13.132
 
 # Not entirely clear why it is needed as not a requirement for huesyncbox directly
 # but the tests fail because HA seems to initialize the zeroconf component which fails due to missing lib.


### PR DESCRIPTION
Looks like some (alpha) dependency from pytest-homeassistant-custom-component
is not available anymore.

Bump to last released HA version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated `huesyncbox` integration to version 2.1.0 for improved compatibility and functionality.

- **Chores**
  - Updated development and testing dependencies for better performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->