### PR TITLE
Don't set (minor_)version manually, use async_update_entry

### DIFF
--- a/custom_components/huesyncbox/__init__.py
+++ b/custom_components/huesyncbox/__init__.py
@@ -132,8 +132,7 @@ def migrate_v1_to_v2(hass: HomeAssistant, config_entry: ConfigEntry):
             # There used to be a repair created here
             # Removed due to adding dependency on automation
 
-    config_entry.version = 2
-    hass.config_entries.async_update_entry(config_entry)
+    hass.config_entries.async_update_entry(config_entry, version=2, minor_version=1)
 
 
 def migrate_v2_1_to_v2_2(hass: HomeAssistant, config_entry: ConfigEntry):
@@ -142,6 +141,4 @@ def migrate_v2_1_to_v2_2(hass: HomeAssistant, config_entry: ConfigEntry):
         hass, DOMAIN, f"automations_using_deleted_mediaplayer_{config_entry.entry_id}"
     )
 
-    config_entry.version = 2
-    config_entry.minor_version = 2
-    hass.config_entries.async_update_entry(config_entry)
+    hass.config_entries.async_update_entry(config_entry, version=2, minor_version=2)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Streamlined migration processes for configuration updates, enhancing clarity and efficiency.
	- Reduced redundancy in version handling, allowing for a more cohesive update experience.

These changes lead to improved maintainability and performance in managing configuration entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->