### PR TITLE
Use entity_registry_enabled_by_default_fixture instead of diy

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,8 +1,10 @@
 from homeassistant.core import HomeAssistant
+import pytest
 
 from .conftest import setup_integration
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor(hass: HomeAssistant, mock_api):
     """Test the total count of sensor entities after integration setup."""
     await setup_integration(hass, mock_api)
@@ -10,7 +12,7 @@ async def test_sensor(hass: HomeAssistant, mock_api):
 
 
 async def test_sensor_default_disabled(hass: HomeAssistant, mock_api):
-    await setup_integration(hass, mock_api, disable_enable_default_all=True)
+    await setup_integration(hass, mock_api)
     assert hass.states.async_entity_ids_count("sensor") == 5
 
 
@@ -34,6 +36,7 @@ async def test_hdmi_status(hass: HomeAssistant, mock_api):
     assert entity.state == "unknown"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_ip_address(hass: HomeAssistant, mock_api):
     await setup_integration(hass, mock_api)
 
@@ -42,18 +45,20 @@ async def test_ip_address(hass: HomeAssistant, mock_api):
     assert entity.state == "1.2.3.4"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_bridge_id(hass: HomeAssistant, mock_api):
     await setup_integration(hass, mock_api)
 
-    entity = hass.states.get("sensor.name_bridge_unique_id")
+    entity = hass.states.get("sensor.name_bridge_id")
     assert entity is not None
     assert entity.state == "bridge_id"
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_bridge_connection_state(hass: HomeAssistant, mock_api):
     await setup_integration(hass, mock_api)
 
-    entity = hass.states.get("sensor.name_bridge_connection_state")
+    entity = hass.states.get("sensor.name_bridge_connection")
     assert entity is not None
     assert entity.state == "connected"
 
@@ -66,10 +71,11 @@ async def test_wifi_strength_not_supported(hass: HomeAssistant, mock_api):
     assert entity is None
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_wifi_strength(hass: HomeAssistant, mock_api):
     await setup_integration(hass, mock_api)
 
-    entity = hass.states.get("sensor.name_wifi_strength")
+    entity = hass.states.get("sensor.name_wifi_quality")
     assert entity is not None
     assert entity.state == "fair"
     assert entity.attributes["icon"] == "mdi:wifi-strength-2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new test fixture to ensure all entities are enabled in the entity registry during testing, enhancing consistency.
	- Updated integration tests for sensor entities to use the new fixture, standardizing the testing environment.

- **Bug Fixes**
	- Modified test functions to reflect updated sensor naming conventions, improving clarity and accuracy in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->