### PR TITLE
Disable content info sensor by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ The following features are available:
 * Bridge ID ⁺
 * IP address ⁺
 * Wifi quality ⁺
+* Content info ⁺
 
-Entities marked with ⁺ are default disabled.
+Entities marked with ⁺ are disabled by default.
 
 ### Behavior
 

--- a/custom_components/huesyncbox/sensor.py
+++ b/custom_components/huesyncbox/sensor.py
@@ -101,6 +101,7 @@ ENTITY_DESCRIPTIONS = [
         key="content_info",  # type: ignore
         icon="mdi:aspect-ratio",  # type: ignore
         entity_category=EntityCategory.DIAGNOSTIC,  # type: ignore
+        entity_registry_enabled_default=False,  # type: ignore
         get_value=lambda api: api.hdmi.content_specs,  # type: ignore
     ),
 ]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -13,7 +13,7 @@ async def test_sensor(hass: HomeAssistant, mock_api):
 
 async def test_sensor_default_disabled(hass: HomeAssistant, mock_api):
     await setup_integration(hass, mock_api)
-    assert hass.states.async_entity_ids_count("sensor") == 5
+    assert hass.states.async_entity_ids_count("sensor") == 4
 
 
 async def test_hdmi_status(hass: HomeAssistant, mock_api):
@@ -80,6 +80,7 @@ async def test_wifi_strength(hass: HomeAssistant, mock_api):
     assert entity.state == "fair"
     assert entity.attributes["icon"] == "mdi:wifi-strength-2"
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_content_info(hass: HomeAssistant, mock_api):
     await setup_integration(hass, mock_api)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new feature highlighting "Content info" in the documentation.
  
- **Documentation**
  - Improved clarity in the README with minor textual modifications.
  - Updated phrasing for better readability regarding default settings.

- **Bug Fixes**
  - Adjusted expected sensor entity count in tests to reflect current behavior. 

- **Tests**
  - Introduced a new pytest fixture to enhance the testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->