### PR TITLE
Bump min HA version for HACS

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Philips Hue Play HDMI Sync Box",
     "render_readme": true,
-    "homeassistant": "2024.4.0"
+    "homeassistant": "2024.7.0"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated compatibility for the Philips Hue Play HDMI Sync Box integration to support Home Assistant version 2024.7.0, ensuring access to the latest features and improvements.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->