### PR TITLE
Fix connection issue with HA 2024.8.0b0

### DIFF
--- a/custom_components/huesyncbox/manifest.json
+++ b/custom_components/huesyncbox/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mvdwetering/huesyncbox/issues",
   "loggers": ["aiohuesyncbox"],
-  "requirements": ["aiohuesyncbox==0.0.27"],
+  "requirements": ["aiohuesyncbox==0.0.28"],
   "version": "0.0.0",
   "zeroconf": ["_huesync._tcp.local."]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Must be same as in the manifest
-aiohuesyncbox==0.0.27
+aiohuesyncbox==0.0.28


### PR DESCRIPTION
aiohuesyncbox did not work with aiohttp 3.10.
This is fixed with aiohuesyncbox 0.0.28.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `aiohuesyncbox` dependency to version `0.0.28`, which may include enhancements and bug fixes.
  
- **Chores**
	- Adjusted dependency version in `requirements.txt` to ensure the latest updates are utilized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->