### PR TITLE
Fix path to zip release file

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -67,6 +67,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./custom_components/huesyncbox.zip
+          asset_path: ./custom_components/huesyncbox/huesyncbox.zip
           asset_name: huesyncbox.zip
           asset_content_type: application/zip


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the asset path in the GitHub Actions workflow to reflect the new directory structure for the `huesyncbox.zip` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->