### PR TITLE
Use icons translations

### DIFF
--- a/custom_components/huesyncbox/icons.json
+++ b/custom_components/huesyncbox/icons.json
@@ -15,13 +15,6 @@
       "intensity": {
         "default": "mdi:sine-wave"
       },
-      "sync_mode": {
-        "state": {
-          "video": "mdi:movie-open",
-          "music": "mdi:music",
-          "game": "mdi:gamepad-variant"
-        }
-      },
       "led_indicator_mode": {
         "default": "mdi:led-variant-on",
         "state": {

--- a/custom_components/huesyncbox/icons.json
+++ b/custom_components/huesyncbox/icons.json
@@ -1,6 +1,90 @@
 {
-    "services": {
-        "set_bridge": "mdi:bridge",
-        "set_sync_state": "mdi:sync"
+  "entity": {
+    "number": {
+      "brightness": {
+        "default": "mdi:brightness-5"
+      }
+    },
+    "select": {
+      "hdmi_input": {
+        "default": "mdi:hdmi-port"
+      },
+      "entertainment_area": {
+        "default": "mdi:lamps"
+      },
+      "intensity": {
+        "default": "mdi:sine-wave"
+      },
+      "sync_mode": {
+        "state": {
+          "video": "mdi:movie-open",
+          "music": "mdi:music",
+          "game": "mdi:gamepad-variant"
+        }
+      },
+      "led_indicator_mode": {
+        "default": "mdi:led-variant-on",
+        "state": {
+          "off": "mdi:led-variant-off",
+          "dimmed": "mdi:led-variant-on",
+          "normal": "mdi:led-on"
+        }
+      }
+    },
+    "sensor": {
+      "bridge_connection_state": {
+        "default": "mdi:connection"
+      },
+      "bridge_unique_id": {
+        "default": "mdi:bridge"
+      },
+      "hdmi1_status": {
+        "default": "mdi:video-input-hdmi"
+      },
+      "hdmi2_status": {
+        "default": "mdi:video-input-hdmi"
+      },
+      "hdmi3_status": {
+        "default": "mdi:video-input-hdmi"
+      },
+      "hdmi4_status": {
+        "default": "mdi:video-input-hdmi"
+      },
+      "ip_address": {
+        "default": "mdi:ip-network"
+      },
+      "wifi_strength": {
+        "default": "mdi:wifi-strength-outline",
+        "state": {
+          "not_connected": "mdi:wifi-strength-off-outline",
+          "weak": "mdi:wifi-strength-1",
+          "fair": "mdi:wifi-strength-2",
+          "good": "mdi:wifi-strength-3",
+          "excellent": "mdi:wifi-strength-4"
+        }
+      },
+      "content_info": {
+        "default": "mdi:aspect-ratio"
+      }
+    },
+    "switch": {
+      "power": {
+        "default": "mdi:power"
+      },
+      "light_sync": {
+        "default": "mdi:television-ambient-light"
+      },
+      "dolby_vision_compatibility": {
+        "default": "mdi:hdr"
+      }
     }
+  },
+  "services": {
+    "set_bridge": {
+      "service": "mdi:bridge"
+    },
+    "set_sync_state": {
+      "service": "mdi:sync"
+    }
+  }
 }

--- a/custom_components/huesyncbox/icons.json
+++ b/custom_components/huesyncbox/icons.json
@@ -15,6 +15,9 @@
       "intensity": {
         "default": "mdi:sine-wave"
       },
+      "sync_mode": {
+        "default": "mdi:multimedia"
+      },
       "led_indicator_mode": {
         "default": "mdi:led-variant-on",
         "state": {

--- a/custom_components/huesyncbox/number.py
+++ b/custom_components/huesyncbox/number.py
@@ -27,7 +27,6 @@ async def set_brightness(api: aiohuesyncbox.HueSyncBox, brightness):
 ENTITY_DESCRIPTIONS = [
     HueSyncBoxNumberEntityDescription(  # type: ignore
         key="brightness",  # type: ignore
-        icon="mdi:brightness-5",  # type: ignore
         native_max_value=100,  # type: ignore
         native_min_value=1,  # type: ignore
         native_step=1,  # type: ignore

--- a/custom_components/huesyncbox/select.py
+++ b/custom_components/huesyncbox/select.py
@@ -118,14 +118,12 @@ async def select_led_indicator_mode(api: aiohuesyncbox.HueSyncBox, mode):
 ENTITY_DESCRIPTIONS = [
     HueSyncBoxSelectEntityDescription(  # type: ignore
         key="hdmi_input",  # type: ignore
-        icon="mdi:hdmi-port",  # type: ignore
         options_fn=available_inputs,
         current_option_fn=current_input,
         select_option_fn=select_input,
     ),
     HueSyncBoxSelectEntityDescription(  # type: ignore
         key="entertainment_area",  # type: ignore
-        icon="mdi:lamps",  # type: ignore
         entity_category=EntityCategory.CONFIG,  # type: ignore
         options_fn=available_entertainment_areas,
         current_option_fn=current_entertainment_area,
@@ -133,7 +131,6 @@ ENTITY_DESCRIPTIONS = [
     ),
     HueSyncBoxSelectEntityDescription(  # type: ignore
         key="intensity",  # type: ignore
-        icon="mdi:sine-wave",  # type: ignore
         options=INTENSITIES,  # type: ignore
         current_option_fn=current_intensity,
         select_option_fn=select_intensity,
@@ -146,7 +143,6 @@ ENTITY_DESCRIPTIONS = [
     ),
     HueSyncBoxSelectEntityDescription(  # type: ignore
         key="led_indicator_mode",  # type: ignore
-        icon="mdi:alarm-light",  # type: ignore
         entity_category=EntityCategory.CONFIG,  # type: ignore
         options=sorted(LED_INDICATOR_MODES),  # type: ignore
         current_option_fn=current_led_indicator_mode,

--- a/custom_components/huesyncbox/sensor.py
+++ b/custom_components/huesyncbox/sensor.py
@@ -18,7 +18,6 @@ from .const import DOMAIN
 @dataclass(frozen=True, kw_only=True)
 class HueSyncBoxSensorEntityDescription(SensorEntityDescription):
     get_value: Callable[[aiohuesyncbox.HueSyncBox], str] = None  # type: ignore[assignment]
-    icons: dict[str, str] | None = None
 
 
 WIFI_STRENGTH_STATES = {
@@ -29,34 +28,32 @@ WIFI_STRENGTH_STATES = {
     4: "excellent",
 }
 
-WIFI_STRENGTH_ICONS = {
-    "not_connected": "mdi:wifi-strength-off-outline",
-    "weak": "mdi:wifi-strength-1",
-    "fair": "mdi:wifi-strength-2",
-    "good": "mdi:wifi-strength-3",
-    "excellent": "mdi:wifi-strength-4",
-}
-
 ENTITY_DESCRIPTIONS = [
     HueSyncBoxSensorEntityDescription(  # type: ignore
         key="bridge_connection_state",  # type: ignore
-        icon="mdi:connection",  # type: ignore
         entity_category=EntityCategory.DIAGNOSTIC,  # type: ignore
         entity_registry_enabled_default=False,  # type: ignore
         device_class=SensorDeviceClass.ENUM,  # type: ignore
-        options=["uninitialized", "disconnected", "connecting", "unauthorized", "connected", "invalidgroup", "streaming", "busy"],  # type: ignore
+        options=[
+            "uninitialized",
+            "disconnected",
+            "connecting",
+            "unauthorized",
+            "connected",
+            "invalidgroup",
+            "streaming",
+            "busy",
+        ],  # type: ignore
         get_value=lambda api: api.hue.connection_state,
     ),
     HueSyncBoxSensorEntityDescription(  # type: ignore
         key="bridge_unique_id",  # type: ignore
-        icon="mdi:bridge",  # type: ignore
         entity_category=EntityCategory.DIAGNOSTIC,  # type: ignore
         entity_registry_enabled_default=False,  # type: ignore
         get_value=lambda api: api.hue.bridge_unique_id,
     ),
     HueSyncBoxSensorEntityDescription(  # type: ignore
         key="hdmi1_status",  # type: ignore
-        icon="mdi:video-input-hdmi",  # type: ignore
         entity_category=EntityCategory.DIAGNOSTIC,  # type: ignore
         device_class=SensorDeviceClass.ENUM,  # type: ignore
         options=["unplugged", "plugged", "linked", "unknown"],  # type: ignore
@@ -64,7 +61,6 @@ ENTITY_DESCRIPTIONS = [
     ),
     HueSyncBoxSensorEntityDescription(  # type: ignore
         key="hdmi2_status",  # type: ignore
-        icon="mdi:video-input-hdmi",  # type: ignore
         entity_category=EntityCategory.DIAGNOSTIC,  # type: ignore
         device_class=SensorDeviceClass.ENUM,  # type: ignore
         options=["unplugged", "plugged", "linked", "unknown"],  # type: ignore
@@ -72,7 +68,6 @@ ENTITY_DESCRIPTIONS = [
     ),
     HueSyncBoxSensorEntityDescription(  # type: ignore
         key="hdmi3_status",  # type: ignore
-        icon="mdi:video-input-hdmi",  # type: ignore
         entity_category=EntityCategory.DIAGNOSTIC,  # type: ignore
         device_class=SensorDeviceClass.ENUM,  # type: ignore
         options=["unplugged", "plugged", "linked", "unknown"],  # type: ignore
@@ -80,7 +75,6 @@ ENTITY_DESCRIPTIONS = [
     ),
     HueSyncBoxSensorEntityDescription(  # type: ignore
         key="hdmi4_status",  # type: ignore
-        icon="mdi:video-input-hdmi",  # type: ignore
         entity_category=EntityCategory.DIAGNOSTIC,  # type: ignore
         device_class=SensorDeviceClass.ENUM,  # type: ignore
         options=["unplugged", "plugged", "linked", "unknown"],  # type: ignore
@@ -88,22 +82,18 @@ ENTITY_DESCRIPTIONS = [
     ),
     HueSyncBoxSensorEntityDescription(  # type: ignore
         key="ip_address",  # type: ignore
-        icon="mdi:ip-network",  # type: ignore
         entity_category=EntityCategory.DIAGNOSTIC,  # type: ignore
         entity_registry_enabled_default=False,  # type: ignore
         get_value=lambda api: api.device.ip_address,
     ),
     HueSyncBoxSensorEntityDescription(  # type: ignore
         key="wifi_strength",  # type: ignore
-        # icon="mdi:wifi",  # type: ignore
-        icons=WIFI_STRENGTH_ICONS,
         entity_category=EntityCategory.DIAGNOSTIC,  # type: ignore
         entity_registry_enabled_default=False,  # type: ignore
         get_value=lambda api: WIFI_STRENGTH_STATES[api.device.wifi.strength],  # type: ignore
     ),
     HueSyncBoxSensorEntityDescription(  # type: ignore
         key="content_info",  # type: ignore
-        icon="mdi:aspect-ratio",  # type: ignore
         entity_category=EntityCategory.DIAGNOSTIC,  # type: ignore
         entity_registry_enabled_default=False,  # type: ignore
         get_value=lambda api: api.hdmi.content_specs,  # type: ignore
@@ -154,12 +144,3 @@ class HueSyncBoxSensor(CoordinatorEntity, SensorEntity):
     def native_value(self) -> str | None:
         """Return the state of the sensor."""
         return self.entity_description.get_value(self.coordinator.api)
-
-    @property
-    def icon(self) -> str | None:
-        """Return the icon."""
-        if self.entity_description.icons is not None:
-            return self.entity_description.icons[
-                self.entity_description.get_value(self.coordinator.api)
-            ]
-        return super().icon

--- a/custom_components/huesyncbox/switch.py
+++ b/custom_components/huesyncbox/switch.py
@@ -24,21 +24,18 @@ class HueSyncBoxSwitchEntityDescription(SwitchEntityDescription):
 ENTITY_DESCRIPTIONS = [
     HueSyncBoxSwitchEntityDescription(  # type: ignore
         key="power",  # type: ignore
-        icon="mdi:power",  # type: ignore
         is_on=lambda api: api.execution.mode != "powersave",
         turn_on=lambda api: api.execution.set_state(mode="passthrough"),
         turn_off=lambda api: api.execution.set_state(mode="powersave"),
     ),
     HueSyncBoxSwitchEntityDescription(  # type: ignore
         key="light_sync",  # type: ignore
-        icon="mdi:television-ambient-light",  # type: ignore
         is_on=lambda api: api.execution.mode not in ["powersave", "passthrough"],
         turn_on=lambda api: api.execution.set_state(sync_active=True),
         turn_off=lambda api: api.execution.set_state(sync_active=False),
     ),
     HueSyncBoxSwitchEntityDescription(  # type: ignore
         key="dolby_vision_compatibility",  # type: ignore
-        icon="mdi:hdr",  # type: ignore
         entity_category=EntityCategory.CONFIG,  # type: ignore
         is_on=lambda api: api.behavior.force_dovi_native == 1,
         turn_on=lambda api: api.behavior.set_force_dovi_native(1),

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -78,7 +78,7 @@ async def test_wifi_strength(hass: HomeAssistant, mock_api):
     entity = hass.states.get("sensor.name_wifi_quality")
     assert entity is not None
     assert entity.state == "fair"
-    assert entity.attributes["icon"] == "mdi:wifi-strength-2"
+
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_content_info(hass: HomeAssistant, mock_api):
@@ -87,4 +87,3 @@ async def test_content_info(hass: HomeAssistant, mock_api):
     entity = hass.states.get("sensor.name_content_info")
     assert entity is not None
     assert entity.state == "1920 x 1080 @ 60 - SDR"
-


### PR DESCRIPTION
Use icon translations introduced few months ago (https://developers.home-assistant.io/blog/2024/01/19/icon-translations/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced icon management with a structured hierarchy categorizing icons by entity types (number, select, sensor, switch).
	- Introduced default and state-specific icons for various attributes in the select and sensor categories.

- **Bug Fixes**
	- Removed icon attributes from several entity descriptions, simplifying visual representation without affecting functionality.

- **Refactor**
	- Streamlined icon handling across different entities, moving towards a more organized and maintainable structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->