### PR TITLE
Remove entity_category=EntityCategory.CONFIG to allow entertainment area as a control.

### DIFF
--- a/custom_components/huesyncbox/select.py
+++ b/custom_components/huesyncbox/select.py
@@ -124,7 +124,6 @@ ENTITY_DESCRIPTIONS = [
     ),
     HueSyncBoxSelectEntityDescription(  # type: ignore
         key="entertainment_area",  # type: ignore
-        entity_category=EntityCategory.CONFIG,  # type: ignore
         options_fn=available_entertainment_areas,
         current_option_fn=current_entertainment_area,
         select_option_fn=select_entertainment_area,


### PR DESCRIPTION
## Remove `entity_category=EntityCategory.CONFIG` to allow entertainment area as control

### Description
This change removes the line `entity_category=EntityCategory.CONFIG` from the `select.py` file in the `huesyncbox` integration. By doing so, the entertainment area selector is now treated as a **control** in Home Assistant instead of being categorized as a **configuration** entity. This enhances usability and aligns the functionality with my expectations as user.

### Changes Made
- File modified: `custom_components/huesyncbox/select.py`
- Line removed: `entity_category=EntityCategory.CONFIG`  

### Motivation
This adjustment allows users to manage the entertainment area directly from the Home Assistant interface as an interactive control, improving daily use and overall user experience.

### Additional Notes
If you have any questions about this approach or need more information, feel free to reach out. I'm happy to collaborate! :)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified categorization for the "entertainment_area" entity by removing the `entity_category` attribute, potentially enhancing its visibility in the user interface.
  
- **Bug Fixes**
	- No bugs reported; existing functionalities remain intact, ensuring a smooth user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->