### PR TITLE
Fix HA 2025.2.0b0 deprecation warning

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     steps:
       - uses: "actions/checkout@v4"
       - name: Set up Python ${{ matrix.python-version }}

--- a/custom_components/huesyncbox/config_flow.py
+++ b/custom_components/huesyncbox/config_flow.py
@@ -9,7 +9,6 @@ from typing import Any
 import aiohuesyncbox
 import voluptuous as vol  # type: ignore
 
-from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import (
     CONF_ACCESS_TOKEN,

--- a/custom_components/huesyncbox/config_flow.py
+++ b/custom_components/huesyncbox/config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
 )
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from . import HueSyncBoxConfigEntry
 from .const import DEFAULT_PORT, DOMAIN, REGISTRATION_ID
@@ -197,7 +198,7 @@ class HueSyncBoxConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_zeroconf(
-        self, discovery_info: zeroconf.ZeroconfServiceInfo
+        self, discovery_info: ZeroconfServiceInfo
     ) -> ConfigFlowResult:
         """Handle zeroconf discovery."""
         _LOGGER.debug("async_step_zeroconf, %s", discovery_info)

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "Philips Hue Play HDMI Sync Box",
-    "homeassistant": "2024.8.0",
+    "homeassistant": "2025.2.0",
     "render_readme": true,
     "zip_release": true,
     "filename": "huesyncbox.zip"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
 -r requirements_test.txt
 
 awesomeversion>=24.0.0
-homeassistant-stubs==2024.8.0
+homeassistant-stubs==2025.2.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 
 mypy==1.11.0
 
-pytest-homeassistant-custom-component==0.13.152
+pytest-homeassistant-custom-component==0.13.205
 
 # Not entirely clear why it is needed as not a requirement for huesyncbox directly
 # but the tests fail because HA seems to initialize the zeroconf component which fails due to missing lib.

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 
 mypy==1.11.0
 
-pytest-homeassistant-custom-component==0.13.205
+pytest-homeassistant-custom-component==0.13.208
 
 # Not entirely clear why it is needed as not a requirement for huesyncbox directly
 # but the tests fail because HA seems to initialize the zeroconf component which fails due to missing lib.


### PR DESCRIPTION
This fixes #145 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated type annotation for Zeroconf service discovery to use standardized import.
	- Improved code consistency in configuration flow handling.
- **New Features**
	- Updated Home Assistant version in configuration for Philips Hue Play HDMI Sync Box.
- **Chores**
	- Updated development and testing dependencies to newer versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->