### PR TITLE
Remove device filter, HA is removing it in 2025.11

### DIFF
--- a/custom_components/huesyncbox/services.yaml
+++ b/custom_components/huesyncbox/services.yaml
@@ -1,7 +1,5 @@
 set_bridge:
   target:
-    device:
-      integration: huesyncbox
     entity:
       integration: huesyncbox
   fields:
@@ -23,8 +21,6 @@ set_bridge:
 
 set_sync_state:
   target:
-    device:
-      integration: huesyncbox
     entity:
       integration: huesyncbox
   fields:


### PR DESCRIPTION
See https://developers.home-assistant.io/blog/2025/10/14/device-filter-removed-from-target-selector/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified Huesyncbox service targeting configuration to focus on entity-level operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->