### PR TITLE
Only log data from configentry

### DIFF
--- a/custom_components/huesyncbox/diagnostics.py
+++ b/custom_components/huesyncbox/diagnostics.py
@@ -18,8 +18,8 @@ async def async_get_config_entry_diagnostics(
     """Return diagnostics for a config entry."""
     data = {}
 
-    data["config_entry"] = async_redact_data(
-        entry.as_dict(), KEYS_TO_REDACT_CONFIG_ENTRY
+    data["config_entry_data"] = async_redact_data(
+        dict(entry.data), KEYS_TO_REDACT_CONFIG_ENTRY
     )
 
     if runtime_data := entry.runtime_data:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -16,9 +16,9 @@ async def test_diagnostics(hass: HomeAssistant, mock_api):
 
     diagnostics = await async_get_config_entry_diagnostics(hass, integration.entry)
 
-    assert "config_entry" in diagnostics
-    assert diagnostics["config_entry"]["data"]["unique_id"] == REDACTED
-    assert diagnostics["config_entry"]["data"]["access_token"] == REDACTED
+    assert "config_entry_data" in diagnostics
+    assert diagnostics["config_entry_data"]["unique_id"] == REDACTED
+    assert diagnostics["config_entry_data"]["access_token"] == REDACTED
 
     assert "api" in diagnostics
     assert diagnostics["api"]["uniqueId"] == REDACTED
@@ -33,9 +33,9 @@ async def test_diagnostics_no_response_yet(hass: HomeAssistant, mock_api):
 
     diagnostics = await async_get_config_entry_diagnostics(hass, integration.entry)
 
-    assert "config_entry" in diagnostics
-    assert diagnostics["config_entry"]["data"]["unique_id"] == REDACTED
-    assert diagnostics["config_entry"]["data"]["access_token"] == REDACTED
+    assert "config_entry_data" in diagnostics
+    assert diagnostics["config_entry_data"]["unique_id"] == REDACTED
+    assert diagnostics["config_entry_data"]["access_token"] == REDACTED
 
     assert "api" in diagnostics
     assert diagnostics["api"] == {}
@@ -48,8 +48,8 @@ async def test_diagnostics_not_setup(hass: HomeAssistant, mock_api):
 
     diagnostics = await async_get_config_entry_diagnostics(hass, integration.entry)
 
-    assert "config_entry" in diagnostics
-    assert diagnostics["config_entry"]["data"]["unique_id"] == REDACTED
-    assert diagnostics["config_entry"]["data"]["access_token"] == REDACTED
+    assert "config_entry_data" in diagnostics
+    assert diagnostics["config_entry_data"]["unique_id"] == REDACTED
+    assert diagnostics["config_entry_data"]["access_token"] == REDACTED
 
     assert "api" not in diagnostics


### PR DESCRIPTION
`config_entry.data` is all that is needed and avoids exposing the unique id of the syncbox in the `discovery_keys.zeroconf` data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the diagnostics data structure and redaction logic for consistency.

* **Tests**
  * Updated diagnostic tests to reflect the restructured data format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->