### PR TITLE
Make WiFi sensor enum

### DIFF
--- a/custom_components/huesyncbox/sensor.py
+++ b/custom_components/huesyncbox/sensor.py
@@ -97,7 +97,7 @@ ENTITY_DESCRIPTIONS = [
         entity_registry_enabled_default=False,
         get_value=lambda api: WIFI_STRENGTH_STATES[api.device.wifi.strength],  # type: ignore[union-attr]
         device_class=SensorDeviceClass.ENUM,
-        options=["weak", "fair", "good", "excellent"],
+        options=["not_connected", "weak", "fair", "good", "excellent"],
     ),
     HueSyncBoxSensorEntityDescription(
         key="content_info",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * wifi_strength sensor now uses enumerated states with predefined categories: not_connected, weak, fair, good, and excellent.
  * Validation of wifi_strength values improved and available states are clearer for integrations and UI displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->