### PR TITLE
Bump min Home Assistant version to 2026.8

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,12 +10,15 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.13", "3.14"]
+        python-version: ["3.14"]
     steps:
       - uses: "actions/checkout@v4"
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: "ubuntu-latest"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Philips Hue Play HDMI Sync Box
 
-Minimum required Home Assistant version is: 2025.12.0
+Minimum required Home Assistant version is: 2026.8.0
 
 [![Contributors](https://img.shields.io/github/contributors/mvdwetering/huesyncbox.svg)](https://github.com/mvdwetering/huesyncbox/graphs/contributors)
 

--- a/bump_min_ha_version.sh
+++ b/bump_min_ha_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # bump_min_ha_version.sh
-# Usage: ./bump_min_ha_version.sh <ha_version> <pytest_homeassistant_version>
-# Example: ./bump_min_ha_version.sh 2025.3.0 0.13.215
+# Usage: ./bump_min_ha_version.sh <ha_version>
+# Example: ./bump_min_ha_version.sh 2025.3.0
 
 
 set -e
@@ -9,33 +9,25 @@ set -e
 # Determine the directory where the script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if [ $# -ne 2 ]; then
-  echo "Usage: $0 <ha_version> <pytest_homeassistant_version>"
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <ha_version>"
 
   # Get the previous version from hacs.json
   CURRENT_HA_VERSION=$(grep -oP '"homeassistant":\s*"\K[0-9.]+' "$SCRIPT_DIR/hacs.json" | head -n1)
   echo "Current minimum Home Assistant version is: $CURRENT_HA_VERSION"
   
-  # Get current pytest-homeassistant-custom-component version
-  CURRENT_PYTEST_HA_VERSION=$(grep -oP 'pytest-homeassistant-custom-component==\K[0-9.]+' "$SCRIPT_DIR/pyproject.toml" | head -n1)
-  echo "Current pytest-homeassistant-custom-component version is: $CURRENT_PYTEST_HA_VERSION"
   exit 1
 fi
 
 NEW_VERSION="$1"
-PYTEST_HA_VERSION="$2"
 
 # Update homeassistant version in hacs.json
 sed -i "s/\"homeassistant\": \"[0-9.]*\"/\"homeassistant\": \"$NEW_VERSION\"/" "$SCRIPT_DIR/hacs.json"
 
-# Update homeassistant-stubs in pyproject.toml
-sed -i "s/homeassistant-stubs==[0-9.]*/homeassistant-stubs==$NEW_VERSION/" "$SCRIPT_DIR/pyproject.toml"
-
-# Update pytest-homeassistant-custom-component
-sed -i "s/pytest-homeassistant-custom-component==[0-9.]*/pytest-homeassistant-custom-component==$PYTEST_HA_VERSION/" "$SCRIPT_DIR/pyproject.toml"
+# Update homeassistant in pyproject.toml
+sed -i "s/homeassistant==[0-9.]*/homeassistant==$NEW_VERSION/" "$SCRIPT_DIR/pyproject.toml"
 
 # Update minimum HA version in README.md
 sed -i "s/Minimum required Home Assistant version is: [0-9.]*/Minimum required Home Assistant version is: $NEW_VERSION/" "$SCRIPT_DIR/README.md"
 
 echo "Minimum HA version bumped to $NEW_VERSION in hacs.json, pyproject.toml, and README.md files."
-echo "pytest-homeassistant-custom-component updated to $PYTEST_HA_VERSION."

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "Philips Hue Play HDMI Sync Box",
-    "homeassistant": "2025.12.0",
+    "homeassistant": "2026.8.0",
     "render_readme": true,
     "zip_release": true,
     "filename": "huesyncbox.zip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ keywords = [
   "hue",
   "huesyncbox",
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 
 # Also update version in manifest.json
 dependencies = ["aiohuesyncbox==0.0.31"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,16 +47,13 @@ Repository = "https://github.com/mvdwetering/huesyncbox"
 dev = [
   "mypy==1.17.0",
   "ruff==0.14.10",
-  "pytest>=7.0.0",
+  "pytest>=9.0.3",
   "pytest-cov",
   "pytest-mock",
-  "pytest-homeassistant-custom-component==0.13.298",
   "awesomeversion>=24.0.0",
-  "homeassistant-stubs==2025.12.0",
-
-  # Pin pycares to avoid aiodns incompatibility with pycares 5.0.0
-  # See: https://github.com/aio-libs/aiodns/issues/214
-  "pycares<5.0.0",
+  "homeassistant==2026.8.0",
+  "pytest-homeassistant-custom-component",
+  "homeassistant-stubs",
 ]
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -99,7 +99,9 @@ async def test_reconfigure_host(hass: HomeAssistant, mock_api: Mock) -> None:
     assert result["step_id"] == "configure"
 
     # Provide different host for existing entry, should update
-    with patch("aiohuesyncbox.HueSyncBox.is_registered", return_value=True):
+    mock_api.is_registered.return_value = True
+    with patch("aiohuesyncbox.HueSyncBox") as huesyncbox_instance:
+        huesyncbox_instance.return_value.__aenter__.return_value = mock_api
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Updated the minimum supported Home Assistant version to 2026.8.0.
  * Python 3.14 or newer is now required.

* **Maintenance**
  * Updated development tooling requirements, including pytest.
  * Simplified the Home Assistant compatibility version-update process.

* **Testing**
  * Updated configuration-flow test coverage for current device registration behavior.

* **Release Improvements**
  * Improved permissions and validation for automated release and build workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->