### PR TITLE
Refine ConfigEntry type hints

### DIFF
--- a/custom_components/huesyncbox/helpers.py
+++ b/custom_components/huesyncbox/helpers.py
@@ -12,12 +12,13 @@ from .const import DOMAIN, LOGGER, MANUFACTURER_NAME
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
+
+    from . import HueSyncBoxConfigEntry
 
 
 async def update_device_registry(
-    hass: HomeAssistant, config_entry: ConfigEntry, api: aiohuesyncbox.HueSyncBox
+    hass: HomeAssistant, config_entry: HueSyncBoxConfigEntry, api: aiohuesyncbox.HueSyncBox
 ) -> None:
     # Add device explicitly to registry so other entities just have to report the identifier to link up
     registry = dr.async_get(hass)
@@ -41,7 +42,7 @@ async def update_device_registry(
 
 
 def update_config_entry_title(
-    hass: HomeAssistant, config_entry: ConfigEntry, new_title: str
+    hass: HomeAssistant, config_entry: HueSyncBoxConfigEntry, new_title: str
 ) -> None:
     hass.config_entries.async_update_entry(config_entry, title=new_title)
 

--- a/custom_components/huesyncbox/number.py
+++ b/custom_components/huesyncbox/number.py
@@ -12,11 +12,12 @@ from .helpers import BrightnessRangeConverter, stop_sync_and_retry_on_invalid_st
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
 
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
     import aiohuesyncbox
+
+    from . import HueSyncBoxConfigEntry
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -48,7 +49,7 @@ ENTITY_DESCRIPTIONS = [
 
 async def async_setup_entry(
     _hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: HueSyncBoxConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator = config_entry.runtime_data.coordinator

--- a/custom_components/huesyncbox/select.py
+++ b/custom_components/huesyncbox/select.py
@@ -15,9 +15,10 @@ from .helpers import get_hue_target_from_id, stop_sync_and_retry_on_invalid_stat
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
 
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from . import HueSyncBoxConfigEntry
 
 LED_INDICATOR_MODES = ["off", "normal", "dimmed"]
 INPUTS = ["input1", "input2", "input3", "input4"]
@@ -156,7 +157,7 @@ ENTITY_DESCRIPTIONS = [
 
 async def async_setup_entry(
     _hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: HueSyncBoxConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator = config_entry.runtime_data.coordinator

--- a/custom_components/huesyncbox/sensor.py
+++ b/custom_components/huesyncbox/sensor.py
@@ -23,6 +23,9 @@ if TYPE_CHECKING:
 
     import aiohuesyncbox
 
+    from . import HueSyncBoxConfigEntry
+
+
 @dataclass(frozen=True, kw_only=True)
 class HueSyncBoxSensorEntityDescription(SensorEntityDescription):
     get_value: Callable[[aiohuesyncbox.HueSyncBox], str] = None  # type: ignore[assignment]
@@ -113,7 +116,7 @@ ENTITY_DESCRIPTIONS = [
 
 async def async_setup_entry(
     _hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: HueSyncBoxConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator = config_entry.runtime_data.coordinator

--- a/custom_components/huesyncbox/switch.py
+++ b/custom_components/huesyncbox/switch.py
@@ -15,9 +15,10 @@ from .helpers import stop_sync_and_retry_on_invalid_state
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
 
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from . import HueSyncBoxConfigEntry
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -58,7 +59,7 @@ ENTITY_DESCRIPTIONS = [
 
 async def async_setup_entry(
     _hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: HueSyncBoxConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator = config_entry.runtime_data.coordinator


### PR DESCRIPTION
Use `HueSyncBoxConfigEntry` to provide more specific type information, leveraging component-specific runtime data and improving type safety and developer experience within the integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal integration consistency by using the appropriate device configuration across setup and device-management components.
  * No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->