### PR TITLE
Add support for 4k and screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Philips Hue Play HDMI Sync Box
+# Philips Hue Play Sync devices
 
 Minimum required Home Assistant version is: 2026.8.0
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,16 @@ Minimum required Home Assistant version is: 2026.8.0
 
 ## About
 
-> Please set up the Philips Hue Play HDMI Sync Box with the Hue App first and make sure it works before setting up this integration.
+> Please set up the Philips Hue Play Sync device with the Hue App first and make sure it works before setting up this integration.
 
-This integration allows you to control and automate your Philips Hue Play HDMI Sync Box from Home Assistant. Use it in automations, dashboards, and scripts to improve your entertainment experience.
+This integration allows you to control and automate your Philips Hue Play Sync devices from Home Assistant. Use it in automations, dashboards, and scripts to improve your entertainment experience.
 
 ## Supported devices
 
-Both the 4K and 8K models are supported.
+- Philips Hue Play HDMI sync box (the classic 4K with 4 HDMI inputs)
+- Philips Hue Play HDMI sync box 4K (single HDMI input)
+- Philips Hue Play HDMI sync box 8K
+- Philips Hue Play Screen Sync
 
 ## Possible use-cases
 
@@ -44,7 +47,7 @@ Entities are created for the following features:
 - Brightness control slider
 - Entertainment area selection
 - HDMI input connection status
-- Dolby Vision compatibility on/off (only on 4K)
+- Dolby Vision compatibility on/off (only on classic 4K)
 - LED indicator mode selection
 - Bridge connection status ⁺
 - Bridge ID sensor ⁺
@@ -56,7 +59,7 @@ Entities marked with ⁺ are disabled by default.
 
 ### Behavior
 
-A few notes on behavior when changing entities. This behavior is just how the box reacts when sending these commands, not something explicitly coded in this integration.
+A few notes on behavior when changing entities. This behavior is just how the device reacts when sending these commands, not something explicitly coded in this integration.
 
 - Enabling light sync will also power on the box
 - Setting sync mode will also power on the box and start light sync on the selected mode
@@ -64,7 +67,7 @@ A few notes on behavior when changing entities. This behavior is just how the bo
 
 ## Data updates
 
-This integration polls the Philips Hue Play HDMI Sync Box every 3 seconds.
+This integration polls the Philips Hue Play Sync device every 3 seconds.
 
 ## Actions
 
@@ -72,13 +75,13 @@ The integration exposes two additional actions.
 
 ### Set bridge
 
-This action allows setting the bridge to be used by the Philips Hue Play HDMI Sync Box. For example when you have 2 different bridges you want to sync to and need to switch.
+This action allows setting the bridge to be used by the Philips Hue Play Sync device. For example when you have 2 different bridges you want to sync to and need to switch.
 
-Note that changing the bridge by the box takes a while (about 15 seconds it seems). After the bridge has changed you might need to (re)select the `entertainment_area` if connectionstate is `invalidgroup` instead of `connected`.
+Note that changing the bridge by the sync device takes a while (about 15 seconds it seems). After the bridge has changed you might need to (re)select the `entertainment_area` if connectionstate is `invalidgroup` instead of `connected`.
 
 | Parameter | Optional | Description |
 | --- | --- | --- |
-| device_id | No | Home Assistant device ID of the Philips Hue Play HDMI Sync Box. |
+| device_id | No | Home Assistant device ID for the Philips Hue Play Sync device. |
 | bridge_id | No | ID of the bridge. A hexadecimal code of 16 characters. |
 | bridge_username | No | Username (a.k.a. application key) valid for the bridge. A long code of random characters. |
 | bridge_clientkey | No | Client key that belongs with the username. A hexadecimal code of 32 characters. |
@@ -88,6 +91,7 @@ YAML action call example:
 ```yaml
 action: huesyncbox.set_bridge
 data:
+  # All values are examples, replace with the ones for your setup
   device_id: 11223344556677889900aabbccddeeff
   bridge_id: 001788FFFE000000
   bridge_username: abcdefghijklmnopqrstuvwxyz1234567890ABCD
@@ -96,11 +100,11 @@ data:
 
 ### Set sync state
 
-Set the state of multiple entities of the Philips Hue Play HDMI Sync Box at once. Using this action makes sure everything is set in the correct order and is more efficient than using separate commands.
+Set the state of multiple entities of the Philips Hue Play Sync device at once. Using this action makes sure everything is set in the correct order and is more efficient than using separate commands.
 
 | Parameter | Optional | Description |
 | --- | --- | --- |
-| device_id | No | Home Assistant device ID of the Philips Hue Play HDMI Sync Box. |
+| device_id | No | Home Assistant device ID for the Philips Hue Play Sync device. |
 | power | Yes | Turn the box on or off. |
 | sync | Yes | Set light sync state on or off. Setting this to on will also turn on the box. |
 | brightness | Yes | Brightness value to set. |
@@ -126,7 +130,7 @@ data:
 
 ## Installation
 
-> Please set up the Philips Hue Play HDMI Sync Box with the Hue App first and make sure it works before setting up this integration.
+> Please set up the Philips Hue Play Sync device with the Hue App first and make sure it works before setting up this integration.
 
 ### Downloading
 
@@ -145,7 +149,7 @@ If the button does not work, or you don't want to use it, follow these steps to 
 
 - Go to your Home Assistant instance
 - Open the HACS page
-- Search for "Philips Hue HDMI Sync Box" in the HACS search bar
+- Search for "Philips Hue Sync" in the HACS search bar
 - Click/tap on the integration to open the integration page
 - Press the Download button to download the integration
 - **Restart Home Assistant**
@@ -163,18 +167,18 @@ If the button does not work, or you don't want to use it, follow these steps to 
 
 ### Configuration
 
-The Philips Hue Play HDMI Sync Box will be discovered automatically in most cases. If not, add it manually via `Settings > Devices and Services` in Home Assistant.
+The Philips Hue Play Sync device will be discovered automatically in most cases. If not, add it manually via `Settings > Devices and Services` in Home Assistant.
 
-For manual configuration, provide the following parameters (found in the Hue app's sync box device settings):
+For manual configuration, provide the following parameters (found in the Hue app's sync device settings):
 
 **IP Address**
 : IP address of the device e.g. 192.168.1.123.
 
 **Identifier**
-: The device identifier of the box e.g. C42996000000
+: The device identifier of the device e.g. C42996000000
 
 ## Removal
 
 This integration follows standard integration removal. No extra steps are required.
 
-Go to "Settings > Devices & Services". Select Philips Hue Play HDMI Sync Box. Click the three dots ⋮ menu and then select Delete.
+Go to "Settings > Devices & Services". Select Philips Hue Play Sync. Click the three dots ⋮ menu and then select Delete.

--- a/custom_components/huesyncbox/helpers.py
+++ b/custom_components/huesyncbox/helpers.py
@@ -29,8 +29,10 @@ async def update_device_registry(
         manufacturer=MANUFACTURER_NAME,
         name=api.device.name,
         model={
-            "HSB1": "Philips Hue Play HDMI sync box 4K",
+            "HSB1": "Philips Hue Play HDMI sync box",
             "HSB2": "Philips Hue Play HDMI sync box 8K",
+            "HSB3": "Philips Hue Play HDMI sync box 4K",
+            "HSC001": "Philips Hue Play Screen Sync",
         }.get(api.device.device_type, None),
         model_id=api.device.device_type,
         sw_version=api.device.firmware_version,

--- a/custom_components/huesyncbox/manifest.json
+++ b/custom_components/huesyncbox/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "huesyncbox",
-  "name": "Philips Hue Play HDMI Sync Box",
+  "name": "Philips Hue Play Sync devices",
 
   "codeowners": [
     "@mvdwetering"

--- a/custom_components/huesyncbox/select.py
+++ b/custom_components/huesyncbox/select.py
@@ -40,11 +40,12 @@ def get_sync_mode(api: aiohuesyncbox.HueSyncBox) -> str:
 
 
 def available_inputs(api: aiohuesyncbox.HueSyncBox) -> list[str]:
-    inputs = []
-    for input_id in INPUTS:
-        input_ = getattr(api.hdmi, input_id)
-        inputs.append(input_.name)
-    return inputs
+    return [
+        getattr(api.hdmi, input_id).name
+        for input_id in INPUTS
+        if getattr(api.hdmi, input_id)
+    ]
+
 
 
 def current_input(api: aiohuesyncbox.HueSyncBox) -> str:
@@ -58,7 +59,7 @@ async def select_input(api: aiohuesyncbox.HueSyncBox, input_name: str) -> None:
     # Inputname is the user given name, so needs to be mapped back to a valid API value."""
     for input_id in INPUTS:
         input_ = getattr(api.hdmi, input_id)
-        if input_name == input_.name:
+        if input_ and input_name == input_.name:
             await api.execution.set_state(
                 hdmi_source=aiohuesyncbox.HdmiSource(input_id)
             )

--- a/custom_components/huesyncbox/select.py
+++ b/custom_components/huesyncbox/select.py
@@ -29,6 +29,7 @@ class HueSyncBoxSelectEntityDescription(SelectEntityDescription):
     options_fn: Callable[[aiohuesyncbox.HueSyncBox], list[str]] | None = None
     current_option_fn: Callable[[aiohuesyncbox.HueSyncBox], str] = None  # type: ignore[assignment]
     select_option_fn: Callable[[aiohuesyncbox.HueSyncBox, str], Coroutine] = None  # type: ignore[assignment]
+    is_supported_fn: Callable[[aiohuesyncbox.HueSyncBox], bool] = lambda _: True
 
 
 def get_sync_mode(api: aiohuesyncbox.HueSyncBox) -> str:
@@ -61,6 +62,11 @@ async def select_input(api: aiohuesyncbox.HueSyncBox, input_name: str) -> None:
             await api.execution.set_state(
                 hdmi_source=aiohuesyncbox.HdmiSource(input_id)
             )
+
+
+def are_inputs_supported(api: aiohuesyncbox.HueSyncBox) -> bool:
+    # Check if at least 2 HDMI inputs are available so there is something to choose from
+    return api.hdmi is not None and api.hdmi.input2 is not None
 
 
 def available_entertainment_areas(api: aiohuesyncbox.HueSyncBox) -> list[str]:
@@ -126,6 +132,7 @@ ENTITY_DESCRIPTIONS = [
         options_fn=available_inputs,
         current_option_fn=current_input,
         select_option_fn=select_input,
+        is_supported_fn=are_inputs_supported,
     ),
     HueSyncBoxSelectEntityDescription(
         key="entertainment_area",
@@ -165,6 +172,7 @@ async def async_setup_entry(
     entities: list[SelectEntity] = [
         HueSyncBoxSelect(coordinator, entity_description)
         for entity_description in ENTITY_DESCRIPTIONS
+        if entity_description.is_supported_fn(coordinator.api)
     ]
 
     async_add_entities(entities)

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Philips Hue Play HDMI Sync Box",
+    "name": "Philips Hue Play Sync devices",
     "homeassistant": "2026.8.0",
     "render_readme": true,
     "zip_release": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "huesyncbox"
 version = "0.0.0"
 license = { text = "Apache-2.0" }
-description = "Custom integration for Home Assistant to control the Philips Hue Play HDMI Sync Box 4K or 8K."
+description = "Custom integration for Home Assistant to control the Philips Hue Play Sync devices (boxes and screen)."
 authors = [
   { name = "Michel van de Wetering", email = "michel.van.de.wetering+huesyncbox@gmail.com" },
 ]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -39,7 +39,7 @@ async def test_device_info(hass: HomeAssistant, mock_api: Mock) -> None:
     assert device is not None
     assert device.name == "Name"
     assert device.manufacturer == "Signify"
-    assert device.model == "Philips Hue Play HDMI sync box 4K"
+    assert device.model == "Philips Hue Play HDMI sync box"
     assert device.model_id == "HSB1"
     assert device.sw_version == "firmwareversion"
     assert device.connections == {("mac", "12:34:56:ab:cd:ef")}

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -47,6 +47,28 @@ async def test_input_unsupported_value(hass: HomeAssistant, mock_api: Mock) -> N
     assert entity is not None
     assert entity.state == "unknown"  # HA seems to map unsupported values to "unknown"
 
+async def test_input_no_hdmi(hass: HomeAssistant, mock_api: Mock) -> None:
+    entity_under_test = "select.name_hdmi_input"
+    mock_api.hdmi = None
+
+    await setup_integration(hass, mock_api)
+
+    # Initial value
+    entity = hass.states.get(entity_under_test)
+    assert entity is None
+
+async def test_input_one_hdmi(hass: HomeAssistant, mock_api: Mock) -> None:
+    entity_under_test = "select.name_hdmi_input"
+    mock_api.hdmi.input2 = None
+    mock_api.hdmi.input3 = None
+    mock_api.hdmi.input4 = None
+
+    await setup_integration(hass, mock_api)
+
+    # Initial value
+    entity = hass.states.get(entity_under_test)
+    assert entity is None
+
 
 async def test_intensity(hass: HomeAssistant, mock_api: Mock) -> None:
     entity_under_test = "select.name_intensity"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -15,6 +15,7 @@ async def test_select(hass: HomeAssistant, mock_api: Mock) -> None:
 
 async def test_input(hass: HomeAssistant, mock_api: Mock) -> None:
     entity_under_test = "select.name_hdmi_input"
+    mock_api.hdmi.input4 = None  # Set an input to None to cover more paths
 
     await setup_integration(hass, mock_api)
 
@@ -22,7 +23,7 @@ async def test_input(hass: HomeAssistant, mock_api: Mock) -> None:
     entity = hass.states.get(entity_under_test)
     assert entity is not None
     assert entity.state == "HDMI 2"
-    assert entity.attributes["options"] == ["HDMI 1", "HDMI 2", "HDMI 3", "HDMI 4"]
+    assert entity.attributes["options"] == ["HDMI 1", "HDMI 2", "HDMI 3"]
 
     # Set value
     await hass.services.async_call(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for identifying Philips Hue Play Sync devices across 4K, 8K, and Screen Sync models.
  - HDMI input selection now appears only when multiple compatible inputs are available.

- **Bug Fixes**
  - Unsupported HDMI controls are hidden on devices without sufficient HDMI inputs.
  - Unavailable HDMI inputs are excluded from selection options.

- **Documentation**
  - Updated setup, configuration, supported-device, action, and removal guidance for the broader Sync device family.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->